### PR TITLE
fix: correção nas tres consultas

### DIFF
--- a/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/database/PromotionRepositoryH2.java
+++ b/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/database/PromotionRepositoryH2.java
@@ -12,77 +12,92 @@ import java.util.List;
 @Repository
 public interface PromotionRepositoryH2 extends PromotionJPARepository{
   @Query(value = """
-        WITH ranked_promotions AS (
-            SELECT 
-                p.promotion_id AS promotionId,
-                p.promotion_name AS promotionName,
-                p.points,
-                p.reviews_rating AS reviewsRating,
-                p.total_reviews AS totalReviews,
-                p.promotion_image AS promotionImage,
-                p.created_at,
-                CASE 
-                    WHEN p.created_at >= DATEADD(DAY, -7, NOW()) THEN 1
-                    WHEN fp.client_id IS NOT NULL THEN 2
-                    ELSE 3
-                END AS ranking,
-                ROW_NUMBER() OVER (PARTITION BY 
+    WITH ranked_promotions AS (
+        SELECT 
+            p.promotion_id AS promotionId,
+            p.promotion_name AS promotionName,
+            cat.name AS category,
+            p.reviews_rating AS reviewsRating,
+            p.total_reviews AS totalReviews,
+            p.promotion_image AS promotionImage,
+            p.created_at,
+            CASE 
+                WHEN p.created_at >= DATEADD('DAY', -7, CURRENT_DATE) THEN 1
+                WHEN fp.client_id IS NOT NULL THEN 2
+                ELSE 3
+            END AS ranking,
+            CASE 
+                WHEN fp.client_id IS NOT NULL THEN TRUE 
+                ELSE FALSE 
+            END AS isFavorite,
+            ROW_NUMBER() OVER (
+                PARTITION BY 
                     CASE 
-                        WHEN p.created_at >= DATEADD(DAY, -7, NOW()) THEN 1 
+                        WHEN p.created_at >= DATEADD('DAY', -7, CURRENT_DATE) THEN 1 
                         ELSE 2 
-                    END ORDER BY p.created_at DESC) AS row_num
-            FROM promotions p
-            LEFT JOIN favorite_promotions fp ON fp.promotion_id = p.promotion_id AND fp.client_id = :clientId
-        )
-        SELECT promotionId, promotionName, points, reviewsRating, totalReviews, promotionImage, created_at
-        FROM ranked_promotions
-        WHERE row_num <= 10
-        ORDER BY ranking, created_at DESC
-    """, nativeQuery = true)
+                    END 
+                ORDER BY p.created_at DESC
+            ) AS row_num
+        FROM promotions p
+        JOIN company c ON p.company_id = c.id
+        JOIN category cat ON c.category_id = cat.id
+        LEFT JOIN favorite_promotions fp 
+            ON fp.promotion_id = p.promotion_id 
+            AND fp.client_id = :clientId
+    )
+    SELECT 
+        promotionId, promotionName, category, reviewsRating, 
+        totalReviews, promotionImage, created_at, isFavorite
+    FROM ranked_promotions
+    WHERE row_num <= 10
+    ORDER BY ranking, created_at DESC
+""", nativeQuery = true)
   List<Tuple> findPromotionsCreatedInLast7Days(@Param("clientId") Long clientId);
 
   @Query(value = """
-        WITH ranked_promotions AS (
-            SELECT 
-                p.promotion_id AS promotionId,
-                p.promotion_name AS promotionName,
-                p.points,
-                p.reviews_rating AS reviewsRating,
-                p.total_reviews AS totalReviews,
-                p.promotion_image AS promotionImage,
-                p.redemptions_last_7_days,
-                CASE 
-                    WHEN p.redemptions_last_7_days > 0 THEN 1
-                    WHEN fp.client_id IS NOT NULL THEN 2
-                    ELSE 3
-                END AS ranking,
-                CASE 
-                    WHEN fp.client_id IS NOT NULL THEN TRUE 
-                    ELSE FALSE 
-                END AS isFavorite,
-                ROW_NUMBER() OVER (
-                    PARTITION BY 
-                        CASE 
-                            WHEN p.redemptions_last_7_days > 0 THEN 1
-                            WHEN fp.client_id IS NOT NULL THEN 2
-                            ELSE 3
-                        END 
-                    ORDER BY 
-                        p.redemptions_last_7_days DESC,
-                        p.promotion_id
-                ) AS row_num
-            FROM promotions p
-            LEFT JOIN favorite_promotions fp 
-                ON fp.promotion_id = p.promotion_id 
-                AND fp.client_id = :clientId
-        )
+    WITH ranked_promotions AS (
         SELECT 
-            promotionId, promotionName, points, reviewsRating, 
-            totalReviews, promotionImage, isFavorite, redemptions_last_7_days
-        FROM ranked_promotions
-        WHERE row_num <= 10
-        ORDER BY ranking, redemptions_last_7_days DESC, promotionId
-    """, nativeQuery = true)
+            p.promotion_id AS promotionId,
+            p.promotion_name AS promotionName,
+            cat.name AS category,
+            p.reviews_rating AS reviewsRating,
+            p.total_reviews AS totalReviews,
+            p.promotion_image AS promotionImage,
+            p.redemptions_last_7_days,
+            CASE 
+                WHEN p.redemptions_last_7_days > 0 THEN 1
+                WHEN fp.client_id IS NOT NULL THEN 2
+                ELSE 3
+            END AS ranking,
+            CASE 
+                WHEN fp.client_id IS NOT NULL THEN TRUE 
+                ELSE FALSE 
+            END AS isFavorite,
+            ROW_NUMBER() OVER (
+                PARTITION BY 
+                    CASE 
+                        WHEN p.redemptions_last_7_days > 0 THEN 1
+                        WHEN fp.client_id IS NOT NULL THEN 2
+                        ELSE 3
+                    END 
+                ORDER BY 
+                    p.redemptions_last_7_days DESC,
+                    p.promotion_id
+            ) AS row_num
+        FROM promotions p
+        JOIN company c ON p.company_id = c.id
+        JOIN category cat ON c.category_id = cat.id
+        LEFT JOIN favorite_promotions fp 
+            ON fp.promotion_id = p.promotion_id 
+            AND fp.client_id = :clientId
+    )
+    SELECT 
+        promotionId, promotionName, category, reviewsRating, 
+        totalReviews, promotionImage, isFavorite, redemptions_last_7_days
+    FROM ranked_promotions
+    WHERE row_num <= 10
+    ORDER BY ranking, redemptions_last_7_days DESC, promotionId
+""", nativeQuery = true)
   List<Tuple> findMostRescuedPromotionsInLast7Days(@Param("clientId") Long clientId);
   @Query(value = "SELECT * FROM promotions WHERE company_id = :companyId", nativeQuery = true)
   List<Tuple> findAllByCompanyId(@Param("companyId") Long companyId);

--- a/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/database/PromotionRepositoryPostgres.java
+++ b/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/database/PromotionRepositoryPostgres.java
@@ -12,77 +12,92 @@ import java.util.List;
 @Repository
 public interface PromotionRepositoryPostgres extends PromotionJPARepository {
   @Query(value = """
-        WITH ranked_promotions AS (
-            SELECT 
-                p.promotion_id AS promotionId,
-                p.promotion_name AS promotionName,
-                p.points,
-                p.reviews_rating AS reviewsRating,
-                p.total_reviews AS totalReviews,
-                p.promotion_image AS promotionImage,
-                p.created_at,
-                CASE 
-                    WHEN p.created_at >= CURRENT_DATE - INTERVAL '7 days' THEN 1
-                    WHEN fp.client_id IS NOT NULL THEN 2
-                    ELSE 3
-                END AS ranking,
-                ROW_NUMBER() OVER (PARTITION BY 
+    WITH ranked_promotions AS (
+        SELECT 
+            p.promotion_id AS promotionId,
+            p.promotion_name AS promotionName,
+            cat.name AS category,
+            p.reviews_rating AS reviewsRating,
+            p.total_reviews AS totalReviews,
+            p.promotion_image AS promotionImage,
+            p.created_at,
+            CASE 
+                WHEN p.created_at >= CURRENT_DATE - INTERVAL '7 days' THEN 1
+                WHEN fp.client_id IS NOT NULL THEN 2
+                ELSE 3
+            END AS ranking,
+            CASE 
+                WHEN fp.client_id IS NOT NULL THEN TRUE 
+                ELSE FALSE 
+            END AS isFavorite,
+            ROW_NUMBER() OVER (
+                PARTITION BY 
                     CASE 
                         WHEN p.created_at >= CURRENT_DATE - INTERVAL '7 days' THEN 1 
                         ELSE 2 
-                    END ORDER BY p.created_at DESC) AS row_num
-            FROM promotions p
-            LEFT JOIN favorite_promotions fp ON fp.promotion_id = p.promotion_id AND fp.client_id = :clientId
-        )
-        SELECT promotionId, promotionName, points, reviewsRating, totalReviews, promotionImage, created_at
-        FROM ranked_promotions
-        WHERE row_num <= 10
-        ORDER BY ranking, created_at DESC
-    """, nativeQuery = true)
+                    END 
+                ORDER BY p.created_at DESC
+            ) AS row_num
+        FROM promotions p
+        JOIN company c ON p.company_id = c.id
+        JOIN category cat ON c.category_id = cat.id
+        LEFT JOIN favorite_promotions fp 
+            ON fp.promotion_id = p.promotion_id 
+            AND fp.client_id = :clientId
+    )
+    SELECT 
+        promotionId, promotionName, category, reviewsRating, 
+        totalReviews, promotionImage, created_at, isFavorite
+    FROM ranked_promotions
+    WHERE row_num <= 10
+    ORDER BY ranking, created_at DESC
+""", nativeQuery = true)
   List<Tuple> findPromotionsCreatedInLast7Days(@Param("clientId") Long clientId);
 
   @Query(value = """
-        WITH ranked_promotions AS (
-            SELECT 
-                p.promotion_id AS promotionId,
-                p.promotion_name AS promotionName,
-                p.points,
-                p.reviews_rating AS reviewsRating,
-                p.total_reviews AS totalReviews,
-                p.promotion_image AS promotionImage,
-                p.redemptions_last_7_days,
-                CASE 
-                    WHEN p.redemptions_last_7_days > 0 THEN 1
-                    WHEN fp.client_id IS NOT NULL THEN 2
-                    ELSE 3
-                END AS ranking,
-                CASE 
-                    WHEN fp.client_id IS NOT NULL THEN TRUE 
-                    ELSE FALSE 
-                END AS isFavorite,
-                ROW_NUMBER() OVER (
-                    PARTITION BY 
-                        CASE 
-                            WHEN p.redemptions_last_7_days > 0 THEN 1
-                            WHEN fp.client_id IS NOT NULL THEN 2
-                            ELSE 3
-                        END 
-                    ORDER BY 
-                        p.redemptions_last_7_days DESC,
-                        p.promotion_id
-                ) AS row_num
-            FROM promotions p
-            LEFT JOIN favorite_promotions fp 
-                ON fp.promotion_id = p.promotion_id 
-                AND fp.client_id = :clientId
-        )
+    WITH ranked_promotions AS (
         SELECT 
-            promotionId, promotionName, points, reviewsRating, 
-            totalReviews, promotionImage, isFavorite, redemptions_last_7_days
-        FROM ranked_promotions
-        WHERE row_num <= 10
-        ORDER BY ranking, redemptions_last_7_days DESC, promotionId
-    """, nativeQuery = true)
+            p.promotion_id AS promotionId,
+            p.promotion_name AS promotionName,
+            cat.name AS category,
+            p.reviews_rating AS reviewsRating,
+            p.total_reviews AS totalReviews,
+            p.promotion_image AS promotionImage,
+            p.redemptions_last_7_days,
+            CASE 
+                WHEN p.redemptions_last_7_days > 0 THEN 1
+                WHEN fp.client_id IS NOT NULL THEN 2
+                ELSE 3
+            END AS ranking,
+            CASE 
+                WHEN fp.client_id IS NOT NULL THEN TRUE 
+                ELSE FALSE 
+            END AS isFavorite,
+            ROW_NUMBER() OVER (
+                PARTITION BY 
+                    CASE 
+                        WHEN p.redemptions_last_7_days > 0 THEN 1
+                        WHEN fp.client_id IS NOT NULL THEN 2
+                        ELSE 3
+                    END 
+                ORDER BY 
+                    p.redemptions_last_7_days DESC,
+                    p.promotion_id
+            ) AS row_num
+        FROM promotions p
+        JOIN company c ON p.company_id = c.id
+        JOIN category cat ON c.category_id = cat.id
+        LEFT JOIN favorite_promotions fp 
+            ON fp.promotion_id = p.promotion_id 
+            AND fp.client_id = :clientId
+    )
+    SELECT 
+        promotionId, promotionName, category, reviewsRating, 
+        totalReviews, promotionImage, isFavorite, redemptions_last_7_days
+    FROM ranked_promotions
+    WHERE row_num <= 10
+    ORDER BY ranking, redemptions_last_7_days DESC, promotionId
+""", nativeQuery = true)
   List<Tuple> findMostRescuedPromotionsInLast7Days(@Param("clientId") Long clientId);
   @Query(value = "SELECT * FROM promotions WHERE company_id = :companyId", nativeQuery = true)
   List<Tuple> findAllByCompanyId(@Param("companyId") Long companyId);

--- a/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/model/dto/GetCompaniesByCategoriesOutput.java
+++ b/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/model/dto/GetCompaniesByCategoriesOutput.java
@@ -1,4 +1,4 @@
 package com.clubeevantagens.authmicroservice.model.dto;
 
-public record GetCompaniesByCategoriesOutput(Long companyId, String companyName, String category, double distance, double reviewsRating, int totalReviews, String companyProfile, boolean isFavorite) {
+public record GetCompaniesByCategoriesOutput(Long companyId, String companyName, String category, double distance, double reviewsRating, int totalReviews, String companyImage, String companyProfile, boolean isFavorite) {
 }

--- a/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/model/dto/GetMostRescuedPromotionsInLast7DaysOutput.java
+++ b/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/model/dto/GetMostRescuedPromotionsInLast7DaysOutput.java
@@ -1,4 +1,4 @@
 package com.clubeevantagens.authmicroservice.model.dto;
 
-public record GetMostRescuedPromotionsInLast7DaysOutput(Long promotionId, String promotionName, Double distance, Double reviewsRating, Integer totalReviews, Integer points, String promotionImage, String companyProfile, Boolean isFavorite) {
+public record GetMostRescuedPromotionsInLast7DaysOutput(Long promotionId, String promotionName, Double distance, Double reviewsRating, Integer totalReviews, String category, String promotionImage, String companyProfile, Boolean isFavorite) {
 }

--- a/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/model/dto/GetMostRescuedPromotionsInLast7DaysProjection.java
+++ b/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/model/dto/GetMostRescuedPromotionsInLast7DaysProjection.java
@@ -1,4 +1,4 @@
 package com.clubeevantagens.authmicroservice.model.dto;
 
-public record GetMostRescuedPromotionsInLast7DaysProjection(Long promotionId, String promotionName, Integer points, Double reviewsRating, Integer totalReviews, String promotionImage, Boolean isFavorite) {
+public record GetMostRescuedPromotionsInLast7DaysProjection(Long promotionId, String promotionName, String category, Double reviewsRating, Integer totalReviews, String promotionImage, Boolean isFavorite) {
 }

--- a/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/model/dto/GetPromotionsCreatedInLast7DaysOutput.java
+++ b/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/model/dto/GetPromotionsCreatedInLast7DaysOutput.java
@@ -1,4 +1,4 @@
 package com.clubeevantagens.authmicroservice.model.dto;
 
-public record GetPromotionsCreatedInLast7DaysOutput(Long promotionId, String promotionName, Double distance, Double reviewsRating, Integer totalReviews, Integer points, String promotionImage, String companyProfile) {
+public record GetPromotionsCreatedInLast7DaysOutput(Long promotionId, String promotionName, Double distance, Double reviewsRating, Integer totalReviews, String category, String promotionImage, String companyProfile, Boolean isFavorite) {
 }

--- a/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/model/dto/GetPromotionsCreatedInLast7DaysProjection.java
+++ b/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/model/dto/GetPromotionsCreatedInLast7DaysProjection.java
@@ -1,4 +1,4 @@
 package com.clubeevantagens.authmicroservice.model.dto;
 
-public record GetPromotionsCreatedInLast7DaysProjection(Long promotionId, String promotionName, Integer points, Double reviewsRating, Integer totalReviews, String promotionImage) {
+public record GetPromotionsCreatedInLast7DaysProjection(Long promotionId, String promotionName, String category, Double reviewsRating, Integer totalReviews, String promotionImage, Boolean isFavorite) {
 }

--- a/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/repository/implementation/PromotionRepositoryImpl.java
+++ b/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/repository/implementation/PromotionRepositoryImpl.java
@@ -35,10 +35,11 @@ public class PromotionRepositoryImpl implements PromotionRepository {
             .map(tuple -> new GetPromotionsCreatedInLast7DaysProjection(
                     tuple.get("promotionId", Long.class),
                     tuple.get("promotionName", String.class),
-                    tuple.get("points", Integer.class),
+                    tuple.get("category", String.class),
                     tuple.get("reviewsRating", Double.class),
                     tuple.get("totalReviews", Integer.class),
-                    tuple.get("promotionImage", String.class)
+                    tuple.get("promotionImage", String.class),
+                    tuple.get("isFavorite", Boolean.class)
             ))
             .collect(Collectors.toList());
   }
@@ -50,7 +51,7 @@ public class PromotionRepositoryImpl implements PromotionRepository {
             .map(tuple -> new GetMostRescuedPromotionsInLast7DaysProjection(
                     tuple.get("promotionId", Long.class),
                     tuple.get("promotionName", String.class),
-                    tuple.get("points", Integer.class),
+                    tuple.get("category", String.class),
                     tuple.get("reviewsRating", Double.class),
                     tuple.get("totalReviews", Integer.class),
                     tuple.get("promotionImage", String.class),

--- a/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/service/GetCompaniesByCategories.java
+++ b/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/service/GetCompaniesByCategories.java
@@ -53,6 +53,7 @@ public class GetCompaniesByCategories {
               rating,
               allReviews.size(),
               "implementar-depois-usando-s3",
+              "implementar-depois-usando-s3",
               projection.isFavorite()
       ));
     }

--- a/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/service/GetMostRescuedPromotionsInLast7Days.java
+++ b/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/service/GetMostRescuedPromotionsInLast7Days.java
@@ -25,7 +25,7 @@ public class GetMostRescuedPromotionsInLast7Days {
               1.5,
               projection.reviewsRating(),
               projection.totalReviews(),
-              projection.points(),
+              projection.category(),
               projection.promotionImage(),
               "company-profile-mock-url",
               projection.isFavorite()

--- a/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/service/GetPromotionsCreatedInLast7Days.java
+++ b/authmicroservice/src/main/java/com/clubeevantagens/authmicroservice/service/GetPromotionsCreatedInLast7Days.java
@@ -29,9 +29,10 @@ public class GetPromotionsCreatedInLast7Days {
               1.5,
               projection.reviewsRating(),
               projection.totalReviews(),
-              projection.points(),
+              projection.category(),
               projection.promotionImage(),
-              "company-profile-mock-url"
+              "company-profile-mock-url",
+              projection.isFavorite()
       ));
     }
 

--- a/authmicroservice/src/test/java/com/clubeevantagens/authmicroservice/application/usecase/GetMostRescuedPromotionsInLast7DaysTest.java
+++ b/authmicroservice/src/test/java/com/clubeevantagens/authmicroservice/application/usecase/GetMostRescuedPromotionsInLast7DaysTest.java
@@ -1,6 +1,7 @@
 package com.clubeevantagens.authmicroservice.application.usecase;
 
 import com.clubeevantagens.authmicroservice.model.dto.*;
+import com.clubeevantagens.authmicroservice.model.enums.CategoryType;
 import com.clubeevantagens.authmicroservice.repository.PromotionRepository;
 import com.clubeevantagens.authmicroservice.service.GetMostRescuedPromotionsInLast7Days;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,9 +32,9 @@ public class GetMostRescuedPromotionsInLast7DaysTest {
   void shouldReturnAListWithPromotionsRedemptionsLast7Days() {
     GetMostRescuedPromotionsInLast7DaysInput input = new GetMostRescuedPromotionsInLast7DaysInput(1L);
 
-    GetMostRescuedPromotionsInLast7DaysProjection promotion1 = new GetMostRescuedPromotionsInLast7DaysProjection(1L, "Pet shop 2 em 1", 150, 5.0, 2, "promotion-image-url", false);
-    GetMostRescuedPromotionsInLast7DaysProjection promotion2 = new GetMostRescuedPromotionsInLast7DaysProjection(2L, "Prato executivo", 150, 4.0, 9, "promotion-image-url", false);
-    GetMostRescuedPromotionsInLast7DaysProjection promotion3 = new GetMostRescuedPromotionsInLast7DaysProjection(3L, "Lanches da Manu", 190, 4.3, 6, "promotion-image-url", false);
+    GetMostRescuedPromotionsInLast7DaysProjection promotion1 = new GetMostRescuedPromotionsInLast7DaysProjection(1L, "Pet shop 2 em 1", CategoryType.PETSHOP.getDisplayName(), 5.0, 2, "promotion-image-url", false);
+    GetMostRescuedPromotionsInLast7DaysProjection promotion2 = new GetMostRescuedPromotionsInLast7DaysProjection(2L, "Prato executivo", CategoryType.ALIMENTACAO.getDisplayName(), 4.0, 9, "promotion-image-url", false);
+    GetMostRescuedPromotionsInLast7DaysProjection promotion3 = new GetMostRescuedPromotionsInLast7DaysProjection(3L, "Lanches da Manu", CategoryType.ALIMENTACAO.getDisplayName(), 4.3, 6, "promotion-image-url", false);
 
     List<GetMostRescuedPromotionsInLast7DaysProjection> promotionsLast7Days = Arrays.asList(promotion1, promotion2, promotion3);
 
@@ -49,26 +50,29 @@ public class GetMostRescuedPromotionsInLast7DaysTest {
     assertThat(output.get(0).distance()).isEqualTo(1.5);
     assertThat(output.get(0).reviewsRating()).isEqualTo(5.0);
     assertThat(output.get(0).totalReviews()).isEqualTo(2);
-    assertThat(output.get(0).points()).isEqualTo(150);
+    assertThat(output.get(0).category()).isEqualTo("PetShop");
     assertThat(output.get(0).promotionImage()).isEqualTo("promotion-image-url");
     assertThat(output.get(0).companyProfile()).isEqualTo("company-profile-mock-url");
+    assertThat(output.get(0).isFavorite()).isFalse();
 
     assertThat(output.get(1).promotionId()).isEqualTo(2L);
     assertThat(output.get(1).promotionName()).isEqualTo("Prato executivo");
     assertThat(output.get(1).distance()).isEqualTo(1.5);
     assertThat(output.get(1).reviewsRating()).isEqualTo(4.0);
     assertThat(output.get(1).totalReviews()).isEqualTo(9);
-    assertThat(output.get(1).points()).isEqualTo(150);
+    assertThat(output.get(1).category()).isEqualTo("Alimentação");
     assertThat(output.get(1).promotionImage()).isEqualTo("promotion-image-url");
     assertThat(output.get(1).companyProfile()).isEqualTo("company-profile-mock-url");
+    assertThat(output.get(1).isFavorite()).isFalse();
 
     assertThat(output.get(2).promotionId()).isEqualTo(3L);
     assertThat(output.get(2).promotionName()).isEqualTo("Lanches da Manu");
     assertThat(output.get(2).distance()).isEqualTo(1.5);
     assertThat(output.get(2).reviewsRating()).isEqualTo(4.3);
     assertThat(output.get(2).totalReviews()).isEqualTo(6);
-    assertThat(output.get(2).points()).isEqualTo(190);
+    assertThat(output.get(2).category()).isEqualTo("Alimentação");
     assertThat(output.get(2).promotionImage()).isEqualTo("promotion-image-url");
     assertThat(output.get(2).companyProfile()).isEqualTo("company-profile-mock-url");
+    assertThat(output.get(2).isFavorite()).isFalse();
   }
 }

--- a/authmicroservice/src/test/java/com/clubeevantagens/authmicroservice/application/usecase/GetPromotionsCreatedInLast7DaysTest.java
+++ b/authmicroservice/src/test/java/com/clubeevantagens/authmicroservice/application/usecase/GetPromotionsCreatedInLast7DaysTest.java
@@ -3,6 +3,7 @@ package com.clubeevantagens.authmicroservice.application.usecase;
 import com.clubeevantagens.authmicroservice.model.dto.GetPromotionsCreatedInLast7DaysInput;
 import com.clubeevantagens.authmicroservice.model.dto.GetPromotionsCreatedInLast7DaysOutput;
 import com.clubeevantagens.authmicroservice.model.dto.GetPromotionsCreatedInLast7DaysProjection;
+import com.clubeevantagens.authmicroservice.model.enums.CategoryType;
 import com.clubeevantagens.authmicroservice.repository.PromotionRepository;
 import com.clubeevantagens.authmicroservice.service.GetPromotionsCreatedInLast7Days;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,9 +36,9 @@ public class GetPromotionsCreatedInLast7DaysTest {
   @DisplayName("Should return a list with the promotions created in last 7 days")
   void shouldReturnAListWithTheLatestPromotions() {
     GetPromotionsCreatedInLast7DaysInput input = new GetPromotionsCreatedInLast7DaysInput(1L);
-    GetPromotionsCreatedInLast7DaysProjection promotion1 = new GetPromotionsCreatedInLast7DaysProjection(1L, "Pet shop 2 em 1", 150, 5.0, 2, "promotion-image-url");
-    GetPromotionsCreatedInLast7DaysProjection promotion2 = new GetPromotionsCreatedInLast7DaysProjection(2L, "Prato executivo", 150, 4.0, 9, "promotion-image-url");
-    GetPromotionsCreatedInLast7DaysProjection promotion3 = new GetPromotionsCreatedInLast7DaysProjection(3L, "Lanches da Manu", 190, 4.3, 6, "promotion-image-url");
+    GetPromotionsCreatedInLast7DaysProjection promotion1 = new GetPromotionsCreatedInLast7DaysProjection(1L, "Pet shop 2 em 1", CategoryType.PETSHOP.getDisplayName(), 5.0, 2, "promotion-image-url", true);
+    GetPromotionsCreatedInLast7DaysProjection promotion2 = new GetPromotionsCreatedInLast7DaysProjection(2L, "Prato executivo", CategoryType.ALIMENTACAO.getDisplayName(), 4.0, 9, "promotion-image-url", false);
+    GetPromotionsCreatedInLast7DaysProjection promotion3 = new GetPromotionsCreatedInLast7DaysProjection(3L, "Lanches da Manu", CategoryType.ALIMENTACAO.getDisplayName(), 4.3, 6, "promotion-image-url", false);
 
     List<GetPromotionsCreatedInLast7DaysProjection> promotionsCreatedInLast7Days = Arrays.asList(promotion1, promotion2, promotion3);
 
@@ -53,26 +54,29 @@ public class GetPromotionsCreatedInLast7DaysTest {
     assertThat(output.get(0).distance()).isEqualTo(1.5);
     assertThat(output.get(0).reviewsRating()).isEqualTo(5.0);
     assertThat(output.get(0).totalReviews()).isEqualTo(2);
-    assertThat(output.get(0).points()).isEqualTo(150);
+    assertThat(output.get(0).category()).isEqualTo("PetShop");
     assertThat(output.get(0).promotionImage()).isEqualTo("promotion-image-url");
     assertThat(output.get(0).companyProfile()).isEqualTo("company-profile-mock-url");
+    assertThat(output.get(0).isFavorite()).isTrue();
 
     assertThat(output.get(1).promotionId()).isEqualTo(2L);
     assertThat(output.get(1).promotionName()).isEqualTo("Prato executivo");
     assertThat(output.get(1).distance()).isEqualTo(1.5);
     assertThat(output.get(1).reviewsRating()).isEqualTo(4.0);
     assertThat(output.get(1).totalReviews()).isEqualTo(9);
-    assertThat(output.get(1).points()).isEqualTo(150);
+    assertThat(output.get(1).category()).isEqualTo("Alimentação");
     assertThat(output.get(1).promotionImage()).isEqualTo("promotion-image-url");
     assertThat(output.get(1).companyProfile()).isEqualTo("company-profile-mock-url");
+    assertThat(output.get(1).isFavorite()).isFalse();
 
     assertThat(output.get(2).promotionId()).isEqualTo(3L);
     assertThat(output.get(2).promotionName()).isEqualTo("Lanches da Manu");
     assertThat(output.get(2).distance()).isEqualTo(1.5);
     assertThat(output.get(2).reviewsRating()).isEqualTo(4.3);
     assertThat(output.get(2).totalReviews()).isEqualTo(6);
-    assertThat(output.get(2).points()).isEqualTo(190);
+    assertThat(output.get(2).category()).isEqualTo("Alimentação");
     assertThat(output.get(2).promotionImage()).isEqualTo("promotion-image-url");
     assertThat(output.get(2).companyProfile()).isEqualTo("company-profile-mock-url");
+    assertThat(output.get(2).isFavorite()).isFalse();
   }
 }

--- a/authmicroservice/src/test/java/com/clubeevantagens/authmicroservice/infra/repository/PromotionRepositoryImplTest.java
+++ b/authmicroservice/src/test/java/com/clubeevantagens/authmicroservice/infra/repository/PromotionRepositoryImplTest.java
@@ -1,12 +1,22 @@
 package com.clubeevantagens.authmicroservice.infra.repository;
 
+import com.clubeevantagens.authmicroservice.database.CompanyJPARepository;
 import com.clubeevantagens.authmicroservice.database.FavoritePromotionJPARepository;
 import com.clubeevantagens.authmicroservice.database.PromotionJPARepository;
 import com.clubeevantagens.authmicroservice.database.model.FavoritePromotionModel;
 import com.clubeevantagens.authmicroservice.database.model.PromotionModel;
 import com.clubeevantagens.authmicroservice.model.Promotion;
+import com.clubeevantagens.authmicroservice.model.data.Address;
+import com.clubeevantagens.authmicroservice.model.data.Category;
+import com.clubeevantagens.authmicroservice.model.data.Company;
+import com.clubeevantagens.authmicroservice.model.data.User;
 import com.clubeevantagens.authmicroservice.model.dto.GetMostRescuedPromotionsInLast7DaysProjection;
 import com.clubeevantagens.authmicroservice.model.dto.GetPromotionsCreatedInLast7DaysProjection;
+import com.clubeevantagens.authmicroservice.model.enums.CategoryType;
+import com.clubeevantagens.authmicroservice.model.enums.States;
+import com.clubeevantagens.authmicroservice.repository.CategoryRepository;
+import com.clubeevantagens.authmicroservice.repository.UserRepository;
+import com.clubeevantagens.authmicroservice.repository.implementation.CompanyRepositoryImpl;
 import com.clubeevantagens.authmicroservice.repository.implementation.PromotionRepositoryImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,22 +35,37 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class PromotionRepositoryImplTest {
 
   @Autowired
+  private CategoryRepository categoryRepository;
+
+  @Autowired
+  private CompanyJPARepository companyJPARepository;
+
+  @Autowired
   private PromotionJPARepository promotionJPARepository;
 
   @Autowired
   private FavoritePromotionJPARepository favoritePromotionJPARepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  private CompanyRepositoryImpl companyRepository;
 
   private PromotionRepositoryImpl promotionRepository;
 
   @BeforeEach
   void setUp() {
     promotionRepository = new PromotionRepositoryImpl(promotionJPARepository);
+    companyRepository = new CompanyRepositoryImpl(companyJPARepository);
   }
 
   @AfterEach
   void tearDown() {
     promotionJPARepository.deleteAll();
+    companyJPARepository.deleteAll();
     favoritePromotionJPARepository.deleteAll();
+    userRepository.deleteAll();
+    categoryRepository.deleteAll();
   }
 
   @Test
@@ -84,8 +109,35 @@ public class PromotionRepositoryImplTest {
   @Test
   @DisplayName("Should return 10 promotions created in the last 7 days in descending order")
   void shouldReturn10LatestPromotions() {
+    User user = new User("example@email.com", "Abc@123");
+    this.userRepository.save(user);
+
+    Category category = new Category();
+    category.setName(CategoryType.PETSHOP);
+    categoryRepository.save(category);
+
+
+    Address address = new Address();
+    address.setCep("96700000");
+    address.setStreet("Rua das Acácias, 123");
+    address.setDistrict("Jardim Primavera");
+    address.setCity("São Lourenço do Sul");
+    address.setContactPhone("51912345678");
+    address.setStates(States.SP);
+
+    Company company = new Company();
+    company.setUser(user);
+    company.setCompanyName("Company");
+    company.setCnpj("01234567890123");
+    company.setPhoneNumber("11999999999");
+    company.setAddress(address);
+    company.setCategory(category);
+    company.setTermsOfUse(true);
+    company.setDateTermsOfUse(LocalDateTime.now());
+    Long companyId = this.companyRepository.save(company);
+
     for (int i = 1; i <= 15; i++) {
-      promotionRepository.save(new Promotion((long) i, "Promotion " + i, 100, "image" + i + ".png"));
+      promotionRepository.save(new Promotion(companyId, "Promotion " + i, 100, "image" + i + ".png"));
     }
     List<GetPromotionsCreatedInLast7DaysProjection> promotions = promotionRepository.findPromotionsCreatedInLast7Days(10L);
     assertThat(promotions).hasSize(10);
@@ -101,17 +153,47 @@ public class PromotionRepositoryImplTest {
   @Test
   @DisplayName("Should return 7 promotions created in the last 7 days plus 3 favorite promotions")
   void shouldReturn7LatestPromotionsPlus3Favorites() {
+    User user = new User("example@email.com", "Abc@123");
+    this.userRepository.save(user);
+
+    Category category = new Category();
+    category.setName(CategoryType.PETSHOP);
+    categoryRepository.save(category);
+
+
+    Address address = new Address();
+    address.setCep("96700000");
+    address.setStreet("Rua das Acácias, 123");
+    address.setDistrict("Jardim Primavera");
+    address.setCity("São Lourenço do Sul");
+    address.setContactPhone("51912345678");
+    address.setStates(States.SP);
+
+    Company company = new Company();
+    company.setUser(user);
+    company.setCompanyName("Company");
+    company.setCnpj("01234567890123");
+    company.setPhoneNumber("11999999999");
+    company.setAddress(address);
+    company.setCategory(category);
+    company.setTermsOfUse(true);
+    company.setDateTermsOfUse(LocalDateTime.now());
+    Long companyId = this.companyRepository.save(company);
+
+    User client = new User("client@email.com", "1234");
+    Long clientId = this.userRepository.save(client).getId();
+
     for (int i = 8; i <= 10; i++) {
-      Promotion favoritePromotion = new Promotion(10L, "Favorite " + i, 100, "image" + i);
+      Promotion favoritePromotion = new Promotion(companyId, "Favorite " + i, 100, "image" + i);
       Long promotionId = promotionRepository.save(favoritePromotion);
-      favoritePromotionJPARepository.save(new FavoritePromotionModel((long) i, 10L, promotionId));
+      favoritePromotionJPARepository.save(new FavoritePromotionModel((long) i, clientId, promotionId));
     }
 
     for (int i = 1; i <= 7; i++) {
-      promotionRepository.save(new Promotion(10L, "Promotion " + i, 100, "image" + i));
+      promotionRepository.save(new Promotion(companyId, "Promotion " + i, 100, "image" + i));
     }
 
-    List<GetPromotionsCreatedInLast7DaysProjection> promotions = promotionRepository.findPromotionsCreatedInLast7Days(10L);
+    List<GetPromotionsCreatedInLast7DaysProjection> promotions = promotionRepository.findPromotionsCreatedInLast7Days(clientId);
     assertThat(promotions).hasSize(10);
     assertThat(promotions.get(7).promotionName()).isEqualTo("Favorite 10");
     assertThat(promotions.get(8).promotionName()).isEqualTo("Favorite 9");
@@ -121,32 +203,92 @@ public class PromotionRepositoryImplTest {
   @Test
   @DisplayName("Should return only favorite promotions if there are no recent promotions")
   void shouldReturnOnlyFavoritesIfNoRecentPromotions() {
+    User user = new User("example@email.com", "Abc@123");
+    this.userRepository.save(user);
+
+    Category category = new Category();
+    category.setName(CategoryType.PETSHOP);
+    categoryRepository.save(category);
+
+
+    Address address = new Address();
+    address.setCep("96700000");
+    address.setStreet("Rua das Acácias, 123");
+    address.setDistrict("Jardim Primavera");
+    address.setCity("São Lourenço do Sul");
+    address.setContactPhone("51912345678");
+    address.setStates(States.SP);
+
+    Company company = new Company();
+    company.setUser(user);
+    company.setCompanyName("Company");
+    company.setCnpj("01234567890123");
+    company.setPhoneNumber("11999999999");
+    company.setAddress(address);
+    company.setCategory(category);
+    company.setTermsOfUse(true);
+    company.setDateTermsOfUse(LocalDateTime.now());
+    Long companyId = this.companyRepository.save(company);
+
+    User client = new User("client@email.com", "1234");
+    Long clientId = this.userRepository.save(client).getId();
+
     for (int i = 0; i <= 10; i++) {
-      Promotion promotion = new Promotion((long) i, 10L, "Promotion " + i, 100, 4.5, 30, 8, 2, LocalDateTime.now().minusDays(10), "image" + i, LocalDateTime.now().minusDays(20));
+      Promotion promotion = new Promotion((long) i, companyId, "Promotion " + i, 100, 4.5, 30, 8, 2, LocalDateTime.now().minusDays(10), "image" + i, LocalDateTime.now().minusDays(20));
       promotionRepository.save(promotion);
     }
 
     for (int i = 1; i <= 3; i++) {
-      Promotion favoritePromotion = new Promotion((long) i, 10L, "Favorite " + i, 100, 4.5, 30, 8, 2, LocalDateTime.now().minusDays(10), "image" + i, LocalDateTime.now().minusDays(10));
+      Promotion favoritePromotion = new Promotion((long) i, companyId, "Favorite " + i, 100, 4.5, 30, 8, 2, LocalDateTime.now().minusDays(10), "image" + i, LocalDateTime.now().minusDays(10));
       promotionRepository.save(favoritePromotion);
-      favoritePromotionJPARepository.save(new FavoritePromotionModel((long) i, 10L, favoritePromotion.getPromotionId()));
+      favoritePromotionJPARepository.save(new FavoritePromotionModel((long) i, clientId, favoritePromotion.getPromotionId()));
     }
-    List<GetPromotionsCreatedInLast7DaysProjection> promotions = promotionRepository.findPromotionsCreatedInLast7Days(10L);
+    List<GetPromotionsCreatedInLast7DaysProjection> promotions = promotionRepository.findPromotionsCreatedInLast7Days(clientId);
     assertThat(promotions).hasSize(10);
   }
 
   @Test
   @DisplayName("Should return the top 10 most redeemed promotions")
   void shouldReturnTop10MostRescuedPromotions() {
+    User user = new User("example@email.com", "Abc@123");
+    this.userRepository.save(user);
+
+    Category category = new Category();
+    category.setName(CategoryType.PETSHOP);
+    categoryRepository.save(category);
+
+
+    Address address = new Address();
+    address.setCep("96700000");
+    address.setStreet("Rua das Acácias, 123");
+    address.setDistrict("Jardim Primavera");
+    address.setCity("São Lourenço do Sul");
+    address.setContactPhone("51912345678");
+    address.setStates(States.SP);
+
+    Company company = new Company();
+    company.setUser(user);
+    company.setCompanyName("Company");
+    company.setCnpj("01234567890123");
+    company.setPhoneNumber("11999999999");
+    company.setAddress(address);
+    company.setCategory(category);
+    company.setTermsOfUse(true);
+    company.setDateTermsOfUse(LocalDateTime.now());
+    Long companyId = this.companyRepository.save(company);
+
+    User client = new User("client@email.com", "1234");
+    Long clientId = this.userRepository.save(client).getId();
+
     for (int i = 1; i <= 15; i++) {
-      Promotion promotion = new Promotion((long) i, 10L, "Promotion " + i, 100, 4.5, 30, i, i, LocalDateTime.now(), "image" + i + ".png", LocalDateTime.now());
+      Promotion promotion = new Promotion((long) i, companyId, "Promotion " + i, 100, 4.5, 30, i, i, LocalDateTime.now(), "image" + i + ".png", LocalDateTime.now());
       promotionRepository.save(promotion);
       if (i <= 5) {
-        favoritePromotionJPARepository.save(new FavoritePromotionModel((long) i, 1L, promotion.getPromotionId()));
+        favoritePromotionJPARepository.save(new FavoritePromotionModel((long) i, clientId, promotion.getPromotionId()));
       }
     }
 
-    List<GetMostRescuedPromotionsInLast7DaysProjection> result = promotionRepository.findMostRescuedPromotionsInLast7Days(1L);
+    List<GetMostRescuedPromotionsInLast7DaysProjection> result = promotionRepository.findMostRescuedPromotionsInLast7Days(clientId);
 
     assertThat(result).hasSize(10);
     assertThat(result.get(0).promotionName()).isEqualTo("Promotion 15");
@@ -164,24 +306,52 @@ public class PromotionRepositoryImplTest {
   @Test
   @DisplayName("Should return the top 7 most redeemed promotions and top 3 favorite promotions")
   void shouldReturnTop7MostRescuedPromotionsAndTop3FavoritePromotions() {
+    User user = new User("example@email.com", "Abc@123");
+    this.userRepository.save(user);
+
+    Category category = new Category();
+    category.setName(CategoryType.PETSHOP);
+    categoryRepository.save(category);
+
+
+    Address address = new Address();
+    address.setCep("96700000");
+    address.setStreet("Rua das Acácias, 123");
+    address.setDistrict("Jardim Primavera");
+    address.setCity("São Lourenço do Sul");
+    address.setContactPhone("51912345678");
+    address.setStates(States.SP);
+
+    Company company = new Company();
+    company.setUser(user);
+    company.setCompanyName("Company");
+    company.setCnpj("01234567890123");
+    company.setPhoneNumber("11999999999");
+    company.setAddress(address);
+    company.setCategory(category);
+    company.setTermsOfUse(true);
+    company.setDateTermsOfUse(LocalDateTime.now());
+    Long companyId = this.companyRepository.save(company);
+
+    User client = new User("client@email.com", "1234");
+    Long clientId = this.userRepository.save(client).getId();
+
     for (int i = 1; i <= 7; i++) {
       Promotion promotion = new Promotion(
-              (long) i, 10L, "Promotion " + i, 100, 4.5, 30, i, i, LocalDateTime.now(), "image" + i + ".png", LocalDateTime.now()
+              (long) i, companyId, "Promotion " + i, 100, 4.5, 30, i, i, LocalDateTime.now(), "image" + i + ".png", LocalDateTime.now()
       );
       promotionRepository.save(promotion);
     }
 
-
-
     for (int i = 8; i <= 10; i++) {
       Promotion favoritePromotion = new Promotion(
-              (long) i, 10L, "Favorite " + i, 100, 4.5, 30, 10, 0, LocalDateTime.now(), "image" + i + ".png", LocalDateTime.now()
+              (long) i, companyId, "Favorite " + i, 100, 4.5, 30, 10, 0, LocalDateTime.now(), "image" + i + ".png", LocalDateTime.now()
       );
       Long promotionId = promotionRepository.save(favoritePromotion);
-      favoritePromotionJPARepository.save(new FavoritePromotionModel((long) i, 2L, promotionId));
+      favoritePromotionJPARepository.save(new FavoritePromotionModel((long) i, clientId, promotionId));
     }
 
-    List<GetMostRescuedPromotionsInLast7DaysProjection> result = promotionRepository.findMostRescuedPromotionsInLast7Days(2L);
+    List<GetMostRescuedPromotionsInLast7DaysProjection> result = promotionRepository.findMostRescuedPromotionsInLast7Days(clientId);
 
     assertThat(result).hasSize(10);
 
@@ -198,9 +368,39 @@ public class PromotionRepositoryImplTest {
   @Test
   @DisplayName("Should return only favorite promotions when there are no redemptions in the last 7 days")
   void shouldReturnOnlyFavoritesWhenNoRecentRedemptions() {
+    User user = new User("example@email.com", "Abc@123");
+    this.userRepository.save(user);
+
+    Category category = new Category();
+    category.setName(CategoryType.PETSHOP);
+    categoryRepository.save(category);
+
+
+    Address address = new Address();
+    address.setCep("96700000");
+    address.setStreet("Rua das Acácias, 123");
+    address.setDistrict("Jardim Primavera");
+    address.setCity("São Lourenço do Sul");
+    address.setContactPhone("51912345678");
+    address.setStates(States.SP);
+
+    Company company = new Company();
+    company.setUser(user);
+    company.setCompanyName("Company");
+    company.setCnpj("01234567890123");
+    company.setPhoneNumber("11999999999");
+    company.setAddress(address);
+    company.setCategory(category);
+    company.setTermsOfUse(true);
+    company.setDateTermsOfUse(LocalDateTime.now());
+    Long companyId = this.companyRepository.save(company);
+
+    User client = new User("client@email.com", "1234");
+    Long clientId = this.userRepository.save(client).getId();
+
     for (int i = 1; i <= 5; i++) {
       Promotion oldPromotion = new Promotion(
-              (long) i, 10L, "Old Promotion " + i, 100, 4.5, 30, 0, 0,
+              (long) i, companyId, "Old Promotion " + i, 100, 4.5, 30, 0, 0,
               LocalDateTime.now().minusDays(10), "image" + i + ".png", LocalDateTime.now().minusDays(20)
       );
       promotionRepository.save(oldPromotion);
@@ -208,14 +408,14 @@ public class PromotionRepositoryImplTest {
 
     for (int i = 6; i <= 8; i++) {
       Promotion favoritePromotion = new Promotion(
-              (long) i, 10L, "Favorite " + i, 100, 4.5, 30, 0, 0,
+              (long) i, companyId, "Favorite " + i, 100, 4.5, 30, 0, 0,
               LocalDateTime.now(), "image" + i + ".png", LocalDateTime.now()
       );
       Long promotionId = promotionRepository.save(favoritePromotion);
-      favoritePromotionJPARepository.save(new FavoritePromotionModel((long) i, 1L, promotionId));
+      favoritePromotionJPARepository.save(new FavoritePromotionModel((long) i, clientId, promotionId));
     }
 
-    List<GetMostRescuedPromotionsInLast7DaysProjection> result = promotionRepository.findMostRescuedPromotionsInLast7Days(1L);
+    List<GetMostRescuedPromotionsInLast7DaysProjection> result = promotionRepository.findMostRescuedPromotionsInLast7Days(clientId);
 
     assertThat(result).hasSize(8);
     assertThat(result.get(0).isFavorite()).isTrue();
@@ -226,15 +426,45 @@ public class PromotionRepositoryImplTest {
   @Test
   @DisplayName("Should return the top 10 most redeemed promotions when there are more than 10")
   void shouldReturnTop10MostRescuedPromotionsWhenMoreThan10Exist() {
+    User user = new User("example@email.com", "Abc@123");
+    this.userRepository.save(user);
+
+    Category category = new Category();
+    category.setName(CategoryType.PETSHOP);
+    categoryRepository.save(category);
+
+
+    Address address = new Address();
+    address.setCep("96700000");
+    address.setStreet("Rua das Acácias, 123");
+    address.setDistrict("Jardim Primavera");
+    address.setCity("São Lourenço do Sul");
+    address.setContactPhone("51912345678");
+    address.setStates(States.SP);
+
+    Company company = new Company();
+    company.setUser(user);
+    company.setCompanyName("Company");
+    company.setCnpj("01234567890123");
+    company.setPhoneNumber("11999999999");
+    company.setAddress(address);
+    company.setCategory(category);
+    company.setTermsOfUse(true);
+    company.setDateTermsOfUse(LocalDateTime.now());
+    Long companyId = this.companyRepository.save(company);
+
+    User client = new User("client@email.com", "1234");
+    Long clientId = this.userRepository.save(client).getId();
+
     for (int i = 1; i <= 15; i++) {
       Promotion promotion = new Promotion(
-              (long) i, 10L, "Promotion " + i, 100, 4.5, 30, i * 10, i * 10,
+              (long) i, companyId, "Promotion " + i, 100, 4.5, 30, i * 10, i * 10,
               LocalDateTime.now(), "image" + i + ".png", LocalDateTime.now()
       );
       promotionRepository.save(promotion);
     }
 
-    List<GetMostRescuedPromotionsInLast7DaysProjection> result = promotionRepository.findMostRescuedPromotionsInLast7Days(1L);
+    List<GetMostRescuedPromotionsInLast7DaysProjection> result = promotionRepository.findMostRescuedPromotionsInLast7Days(clientId);
 
     assertThat(result).hasSize(10);
     assertThat(result.get(0).promotionName()).isEqualTo("Promotion 15");


### PR DESCRIPTION
Foi feito correção nas três consultas, houve um ajuste na query e no data transfer object de saída dos endpoints referentes a 
- Área de destaque
- Área de novidades

e uma correção no caso de uso da Área de favoritos que acabei esquecendo da propriedade referente a imagem de fundo da companhia que ainda não foi implementada, portanto está "hard coded".